### PR TITLE
Removing default amount float number 1.0, since documentation doesn't…

### DIFF
--- a/src/CurrencyConversion.php
+++ b/src/CurrencyConversion.php
@@ -41,7 +41,7 @@ class CurrencyConversion extends API
     /**
      * @var float
      */
-    private $amount = 1.00;
+    private $amount;
 
     /**
      * @var array
@@ -71,9 +71,12 @@ class CurrencyConversion extends API
 
             $params = [
                 'from'   => $this->from,
-                'to'     => $this->to,
-                'amount' => $this->amount
+                'to'     => $this->to
             ];
+
+            if ($this->amount) {
+                $params['amount'] = $this->amount;
+            }
 
             if ($this->places) {
                 $params['places'] = $this->places;


### PR DESCRIPTION
… require it. It will always be 1 if you don't pass amount as query param to the api